### PR TITLE
Fix/typeorm v0.3.16

### DIFF
--- a/src/commands/config.command.ts
+++ b/src/commands/config.command.ts
@@ -30,7 +30,7 @@ export class ConfigCommand implements yargs.CommandModule {
     try {
       configureConnection({
         root: args.root as string,
-        configName: args.configName as string,
+        configName: args.datasource as string,
         connection: args.connection as string,
       })
       const option = await getConnectionOptions()

--- a/src/commands/create.command.ts
+++ b/src/commands/create.command.ts
@@ -40,7 +40,7 @@ export class CreateCommand implements yargs.CommandModule {
     const spinner = ora('Loading ormconfig').start()
     const configureOption = {
       root: args.root as string,
-      configName: args.configName as string,
+      configName: args.datasource as string,
       connection: args.connection as string,
     }
 

--- a/src/commands/seed.command.ts
+++ b/src/commands/seed.command.ts
@@ -39,7 +39,7 @@ export class SeedCommand implements yargs.CommandModule {
     const spinner = ora('Loading ormconfig').start()
     const configureOption = {
       root: args.root as string,
-      configName: args.configName as string,
+      configName: args.datasource as string,
       connection: args.connection as string,
     }
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -71,7 +71,7 @@ export const getConnectionOptions = async (): Promise<ConnectionOptions> => {
       configName: configureOption.configName,
     })
     let o = (await reader.all() as unknown as Array<{dataSource: DataSource, baseDirectory: string}>)
-    let options = o.map(option => option.dataSource) as Array<DataSource>
+    let options = o.map(option => option.dataSource || option) as Array<DataSource>
 
     if (connection !== undefined && connection !== '') {
       const filteredOptions = options.filter((o) => o.name === connection)


### PR DESCRIPTION
### Problem:
After upgrading typeorm to v0.3.16, seeding stopped working due to:
- ``configName`` is always undefined as it's not provided from args.
- While creating the connection, it looks for ``datasource`` property in the connection options which doesn't exist.

### Proposed Solution:
- Replaced ``args.configName`` with ``args.datasource`` to allow importing config files with different names.
- Added a fallback for ``option.datasource`